### PR TITLE
Add Laravel 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,22 @@ matrix:
       env: LARAVEL='^6' TESTBENCH='^4'
     - php: 7.3
       env: LARAVEL='^7' TESTBENCH='^5'
+    - php: 7.3
+      env: LARAVEL='^8' TESTBENCH='6.x-dev'
+    - php: 7.4
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
+    - php: 7.4
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
+    - php: 7.4
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.4
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
+    - php: 7.4
+      env: LARAVEL='^6' TESTBENCH='^4'
+    - php: 7.4
+      env: LARAVEL='^7' TESTBENCH='^5'
+    - php: 7.4
+      env: LARAVEL='^8' TESTBENCH='6.x-dev'
 
 before_install:
   - mysql -e 'CREATE DATABASE db_rebuild;'

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   ],
   "require": {
     "php": ">=7.1.0",
-    "illuminate/support": "^5.5|^6.0|^7.0",
-    "illuminate/console": "^5.5|^6.0|^7.0",
-    "illuminate/database": "^5.5|^6.0|^7.0"
+    "illuminate/support": "^5.5|^6.0|^7.0|^8.0",
+    "illuminate/console": "^5.5|^6.0|^7.0|^8.0",
+    "illuminate/database": "^5.5|^6.0|^7.0|^8.0"
   },
   "autoload": {
     "psr-4": {
@@ -49,9 +49,11 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.12",
     "phpunit/phpunit": "^6.0|^7.0|^8.0",
-    "orchestra/testbench": "^3.5|^4.0|^5.0",
-    "orchestra/database": "^3.5|^4.0|^5.0",
+    "orchestra/testbench": "^3.5|^4.0|^5.0|dev-6.x",
+    "orchestra/database": "^3.5|^4.0|^5.0|dev-6.x",
     "phpmd/phpmd": "^2.6",
     "phpstan/phpstan": "^0.12"
-  }
+  },
+  "prefer-stable": true,
+  "minimum-stability": "dev"
 }

--- a/tests/Feature/DbRebuildCommandTest.php
+++ b/tests/Feature/DbRebuildCommandTest.php
@@ -14,7 +14,7 @@ class DbRebuildCommandTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * @var bool 
+     * @var bool
      */
     public $mockConsoleOutput = false;
 


### PR DESCRIPTION
This currently relies on orchestra/database 6.x branch as it doesn't have a tag yet.

